### PR TITLE
Make Json deserialization more tolerant of changes to API

### DIFF
--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
-using AcmeDirectory = System.Collections.Generic.Dictionary<string, System.Uri>;
+using AcmeDirectory = System.Collections.Generic.Dictionary<string, System.Object>;
 
 namespace Certes.Acme
 {
@@ -61,7 +61,7 @@ namespace Certes.Acme
         public async Task<Uri> GetResourceUri(string resourceType)
         {
             await FetchDirectory(false);
-            return this.directory[resourceType];
+            return new Uri(this.directory[resourceType] as String);
         }
 
         /// <summary>

--- a/src/Certes/Acme/EntityBase.cs
+++ b/src/Certes/Acme/EntityBase.cs
@@ -1,4 +1,7 @@
-﻿namespace Certes.Acme
+﻿using System;
+using System.Collections.Generic;
+
+namespace Certes.Acme
 {
     /// <summary>
     /// Represents an ACME entity.

--- a/src/Certes/Json/JsonUtil.cs
+++ b/src/Certes/Json/JsonUtil.cs
@@ -18,7 +18,8 @@ namespace Certes.Json
             var jsonSettings = new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+				MissingMemberHandling = MissingMemberHandling.Ignore
             };
 
             jsonSettings.Converters.Add(new StringEnumConverter());

--- a/src/Certes/Json/JsonUtil.cs
+++ b/src/Certes/Json/JsonUtil.cs
@@ -19,7 +19,7 @@ namespace Certes.Json
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore,
-				MissingMemberHandling = MissingMemberHandling.Ignore
+                MissingMemberHandling = MissingMemberHandling.Ignore
             };
 
             jsonSettings.Converters.Add(new StringEnumConverter());


### PR DESCRIPTION
This is a quick patch for issue #5 -- LE added an object to the response JSON, which couldn't be resolved to a URI. I generalized AcmeDirectory to a Dictionary<string, Object> so that the JSON can be deserialized.