### PR TITLE
feat : Allow clients to specify Subject Alternative Names while creat…

### DIFF
--- a/src/Certes/Pkcs/CertificationRequestBuilderBase.cs
+++ b/src/Certes/Pkcs/CertificationRequestBuilderBase.cs
@@ -41,13 +41,14 @@ namespace Certes.Pkcs
         /// <value>
         /// The subject alternative names.
         /// </value>
-        public IList<string> SubjectAlternativeNames { get; } = new List<string>();
+        public IList<string> SubjectAlternativeNames { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CertificationRequestBuilderBase"/> class.
         /// </summary>
         public CertificationRequestBuilderBase()
         {
+			SubjectAlternativeNames = new List<string>();
         }
 
         /// <summary>


### PR DESCRIPTION
feat : Allow clients to specify Subject Alternative Names while creating CSR. Constructor for CertificationRequestBuilderBase ensure the SubjectAlternativeName is not null thus preserving logic in place
