### PR TITLE
Added net47 to Certes

### DIFF
--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45'" />
   </ItemGroup>
 
 </Project>

--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net47</TargetFrameworks>
     <Version>1.0.0</Version>
     <Authors>Certes Contributors</Authors>
     <Company />
@@ -45,8 +45,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" Condition="'$(TargetFramework)' == 'net45'" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45'" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Included net47 in Certes.csproj TargetFrameworks as well as in the relevant package reference conditions. I also had to update the System.ValueTuple version to 4.4.0. This should address Issue #18 (Certes fails to load on .Net Framework v4.7).