### PR TITLE
Update references in 1.1.2 to work with BouncyCastle 1.8.1.3

### DIFF
--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -43,10 +43,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45'" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Certes.Tests.Web/Certes.Tests.Web.csproj
+++ b/test/Certes.Tests.Web/Certes.Tests.Web.csproj
@@ -19,7 +19,7 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs" Link="Properties\AssemblyInfo.Shared.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.0-beta1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
 

--- a/test/Certes.Tests.Web/Certes.Tests.Web.csproj
+++ b/test/Certes.Tests.Web/Certes.Tests.Web.csproj
@@ -19,7 +19,7 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs" Link="Properties\AssemblyInfo.Shared.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.0-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
 

--- a/test/Certes.Tests/Certes.Tests.csproj
+++ b/test/Certes.Tests/Certes.Tests.csproj
@@ -15,11 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" Condition="'$(TargetFramework)' == 'net47'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Moq" Version="4.7.127" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Version 1.1.2 of Certes nuget does not work with BouncyCastle 1.8.1.3 (at minimum in .NET standard 2.00), get runtime error when calling AddNames.
```
System.MissingFieldException: 
'Field not found: 'Org.BouncyCastle.Asn1.X509.X509Name.DefaultLookup'.'
```
Updating and compiling Certes with updated packages seems to have resolve this issue.