### PR TITLE
Remove codecov upload token for appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ environment:
   ver_offset: 360
   beta_build_Ver: 1
   rc_build_Ver: 1
-  codecov_upload_token:
-    secure: DxYtxftZ1rpZhZzixRqY3hHFrlEZlh62XPV4tcO+zxdsRNZWPSEl967VpRevAPSo
 
 branches:
   # whitelist
@@ -84,9 +82,9 @@ test_script:
   - ps: cd ../../
 
 after_test:
-  - IF NOT "%codecov_upload_token%" == "" npm install codecov -g
-  - IF NOT "%codecov_upload_token%" == "" codecov -f "./build/Certes.Tests.coverage.xml" -t %codecov_upload_token%
-  - IF NOT "%codecov_upload_token%" == "" codecov -f "./build/Certes.Tests.Integration.coverage.xml" -t %codecov_upload_token%
+  - npm install codecov -g
+  - codecov -f "./build/Certes.Tests.coverage.xml"
+  - codecov -f "./build/Certes.Tests.Integration.coverage.xml"
 
 configuration: Release
 

--- a/test/Certes.Tests.Integration/IntegrationHelper.cs
+++ b/test/Certes.Tests.Integration/IntegrationHelper.cs
@@ -17,7 +17,7 @@ namespace Certes
 
         private static Uri[] StagingServersV1 = new[]
         {
-            new Uri("https://localhost:4430/directory"),
+            new Uri("https://lo0.in:4430/directory"),
             new Uri("https://boulder-certes-ci.dymetis.com:4430/directory"),
             WellKnownServers.LetsEncryptStaging,
         };
@@ -106,7 +106,7 @@ namespace Certes
             }
 
             var servers = new[] {
-                new Uri("https://localhost:4431/directory"),
+                new Uri("https://lo0.in:4431/directory"),
                 new Uri("https://boulder-certes-ci.dymetis.com:4431/directory"),
                 WellKnownServers.LetsEncryptStagingV2,
             };


### PR DESCRIPTION
## Description

Codecov upload token is optional for public repo.
Removing it enables coverage check for pull requests.
