### PR TITLE
Fix NRE when server response has no Content-Type header

### DIFF
--- a/src/Certes/Acme/AcmeHttpClient.cs
+++ b/src/Certes/Acme/AcmeHttpClient.cs
@@ -135,7 +135,7 @@ namespace Certes.Acme
 
             if (response.IsSuccessStatusCode)
             {
-                if (IsJsonMedia(response.Content?.Headers.ContentType.MediaType))
+                if (IsJsonMedia(response.Content?.Headers.ContentType?.MediaType))
                 {
                     var json = await response.Content.ReadAsStringAsync();
                     resource = JsonConvert.DeserializeObject<T>(json);

--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -167,7 +167,7 @@ namespace Certes.Acme
             var data = new AcmeResponse<T>();
 
             ParseHeaders(data, response);
-            if (IsJsonMedia(response.Content?.Headers.ContentType.MediaType))
+            if (IsJsonMedia(response.Content?.Headers.ContentType?.MediaType))
             {
                 var json = await response.Content.ReadAsStringAsync();
                 data.Json = json;
@@ -235,7 +235,7 @@ namespace Certes.Acme
                     .ToArray();
             }
 
-            data.ContentType = response.Content?.Headers.ContentType.MediaType;
+            data.ContentType = response.Content?.Headers.ContentType?.MediaType;
         }
 
         private static bool IsJsonMedia(string mediaType)


### PR DESCRIPTION
## Description

add `null` check when processing HTTP response
