### PR TITLE
Fix NRE when server response has no Content-Type header (#61)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.3.{build}
+version: 1.1.4.{build}
 build:
   verbosity: minimal
   project: Certes.sln

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.1.4]
+### Changed
+- Fix error when processing server response without `Content-Type` header
+- Fix `full-chain-off` option for CLI
+
+## [1.1.3] - 2017-11-23
+### Changed
 - Fix MissingFieldException when running with BouncyCastle v1.8.1.3 ([#22][i22])
 
 ## [1.1.2] - 2017-09-27
@@ -29,6 +35,8 @@ All notable changes to this project will be documented in this file.
 [1.1.0]: https://github.com/fszlin/certes/compare/v1.0.7...v1.1.0
 [1.1.1]: https://github.com/fszlin/certes/compare/v1.1.0...v1.1.1
 [1.1.2]: https://github.com/fszlin/certes/compare/v1.1.1...v1.1.2
+[1.1.3]: https://github.com/fszlin/certes/compare/v1.1.2...v1.1.3
+[1.1.4]: https://github.com/fszlin/certes/compare/v1.1.3...v1.1.4
 
 [i5]: https://github.com/fszlin/certes/issues/5
 [i22]: https://github.com/fszlin/certes/issues/22

--- a/src/Certes.Cli/Processors/CertificateCommand.cs
+++ b/src/Certes.Cli/Processors/CertificateCommand.cs
@@ -65,6 +65,12 @@ namespace Certes.Cli.Processors
                 }
 
                 var pfxBuilder = cert.ToPfx();
+
+                if (Options.NoChain)
+                {
+                    pfxBuilder.FullChain = false;
+                }
+
                 var pfx = pfxBuilder.Build(Options.Name, Options.Password);
                 await FileUtil.WriteAllBytes(Options.ExportPfx, pfx);
             }

--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -164,7 +164,7 @@ namespace Certes.Acme
 
         private async Task<AcmeRespone<T>> ReadResponse<T>(HttpResponseMessage response, string resourceType = null)
         {
-            var data = new AcmeResponse<T>();
+            var data = new AcmeRespone<T>();
 
             ParseHeaders(data, response);
             if (IsJsonMedia(response.Content?.Headers.ContentType?.MediaType))

--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -164,8 +164,10 @@ namespace Certes.Acme
 
         private async Task<AcmeRespone<T>> ReadResponse<T>(HttpResponseMessage response, string resourceType = null)
         {
-            var data = new AcmeRespone<T>();
-            if (IsJsonMedia(response.Content?.Headers.ContentType.MediaType))
+            var data = new AcmeResponse<T>();
+
+            ParseHeaders(data, response);
+            if (IsJsonMedia(response.Content?.Headers.ContentType?.MediaType))
             {
                 var json = await response.Content.ReadAsStringAsync();
                 data.Json = json;
@@ -182,14 +184,16 @@ namespace Certes.Acme
                 {
                     data.Error = JsonConvert.DeserializeObject<AcmeError>(json, jsonSettings);
                 }
+
+                // take the replay-nonce from JOSN response
+                // it appears the nonces returned with certificate are invalid
+                nonce = data.ReplayNonce;
             }
             else if (response.Content?.Headers.ContentLength > 0)
             {
                 data.Raw = await response.Content.ReadAsByteArrayAsync();
             }
 
-            ParseHeaders(data, response);
-            this.nonce = data.ReplayNonce;
             return data;
         }
 
@@ -231,7 +235,7 @@ namespace Certes.Acme
                     .ToArray();
             }
 
-            data.ContentType = response.Content?.Headers.ContentType.MediaType;
+            data.ContentType = response.Content?.Headers.ContentType?.MediaType;
         }
 
         private static bool IsJsonMedia(string mediaType)


### PR DESCRIPTION
* add `null` check when processing HTTP response