### PR TITLE
Fix Certes.Acme.Resource.Challenge error property

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Export full chain certification in PEM ([#87][i87])
 - Support custom `HttpClient` ([#95][i95])
+- Add `Challenge.Error` for challenge valdidation error ([#99][i99])
 
 ### Changed
 - Encapsulating ACME errors in exceptions ([#65][i65])
@@ -68,3 +69,4 @@ All notable changes to this project will be documented in this file.
 [i86]: https://github.com/fszlin/certes/issues/86
 [i87]: https://github.com/fszlin/certes/issues/87
 [i95]: https://github.com/fszlin/certes/issues/95
+[i99]: https://github.com/fszlin/certes/issues/99

--- a/src/Certes/Acme/Resource/Challenge.cs
+++ b/src/Certes/Acme/Resource/Challenge.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 
 namespace Certes.Acme.Resource
 {
@@ -46,13 +45,14 @@ namespace Certes.Acme.Resource
         public DateTimeOffset? Validated { get; set; }
 
         /// <summary>
-        /// Gets or sets the errors.
+        /// Gets or sets the error.
+        /// Only if the status is invalid
         /// </summary>
         /// <value>
         /// The errors.
         /// </value>
-        [JsonProperty("errors")]
-        public IList<object> Errors { get; set; }
+        [JsonProperty("error")]
+        public AcmeError Error { get; set; }
 
         /// <summary>
         /// Gets or sets the token.

--- a/src/Certes/Acme/Resource/Challenge.cs
+++ b/src/Certes/Acme/Resource/Challenge.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Certes.Acme.Resource
 {
@@ -53,6 +54,16 @@ namespace Certes.Acme.Resource
         /// </value>
         [JsonProperty("error")]
         public AcmeError Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the errors.
+        /// </summary>
+        /// <value>
+        /// The errors.
+        /// </value>
+        [JsonProperty("errors")]
+        [Obsolete("Use Challenge.Error instead.")]
+        public IList<object> Errors { get; set; }
 
         /// <summary>
         /// Gets or sets the token.

--- a/test/Certes.Tests/Acme/Resource/ChallengeTests.cs
+++ b/test/Certes.Tests/Acme/Resource/ChallengeTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Certes.Acme;
 using Certes.Acme.Resource;
 using Xunit;
 
@@ -10,7 +11,7 @@ namespace Certes.Tests.Acme.Resource
         public void CanGetSetProperties()
         {
             var entity = new Challenge();
-            entity.VerifyGetterSetter(e => e.Errors, new object[0]);
+            entity.VerifyGetterSetter(e => e.Error, new AcmeError());
             entity.VerifyGetterSetter(e => e.Status, ChallengeStatus.Invalid);
             entity.VerifyGetterSetter(e => e.Token, "certes");
             entity.VerifyGetterSetter(e => e.Type, "http-01");

--- a/test/Certes.Tests/Acme/Resource/ChallengeTests.cs
+++ b/test/Certes.Tests/Acme/Resource/ChallengeTests.cs
@@ -11,6 +11,7 @@ namespace Certes.Tests.Acme.Resource
         public void CanGetSetProperties()
         {
             var entity = new Challenge();
+            entity.VerifyGetterSetter(e => e.Errors, new object[0]);
             entity.VerifyGetterSetter(e => e.Error, new AcmeError());
             entity.VerifyGetterSetter(e => e.Status, ChallengeStatus.Invalid);
             entity.VerifyGetterSetter(e => e.Token, "certes");


### PR DESCRIPTION
Fixes #99

The ACME response when a challenge validation is invalid has changed in draft 10.
This fix should parse the error correctly.