### PR TITLE
Changed to Newtonsoft.Json 10.0.3 for PowerShell Core

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Revert `Newtonsoft.Json` to `v10.0.3` for `PowerShell Core` ([#112][i112])
+
 ## [2.2.1] - 2018-05-15
 ### Added
 - Strong name signing ([#106][i106])
@@ -87,3 +90,4 @@ All notable changes to this project will be documented in this file.
 [i99]: https://github.com/fszlin/certes/issues/99
 [i100]: https://github.com/fszlin/certes/issues/100
 [i106]: https://github.com/fszlin/certes/issues/106
+[i112]: https://github.com/fszlin/certes/issues/112

--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net47'" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'net45'" />


### PR DESCRIPTION
PowerShell Core only supports one version of a referenced assembly per session and it already references Newtonsoft.Json 10.0.3 internally, so provides no opportunity for Certes to reference version 11.x. Until this situation is resolved by Microsoft (potentially in PowerShell Core 6.2) the only workaround is to change the dependency here. See https://github.com/PowerShell/PowerShell/issues/2083 and https://github.com/PowerShell/PowerShell/issues/6757

## Description

This change fixes TypeInitializationException when instantiating AcmeContext(Uri directoryUri) from PowerShell Core.
