### PR TITLE
Add friendly-name options for pfx-certificates with certes-cli

### DIFF
--- a/src/Certes.Cli/Commands/CertificatePfxCommand.cs
+++ b/src/Certes.Cli/Commands/CertificatePfxCommand.cs
@@ -11,6 +11,7 @@ namespace Certes.Cli.Commands
     internal class CertificatePfxCommand : CertificateCommand, ICliCommand
     {
         private const string CommandText = "pfx";
+        private const string FriendlyNameOption = "friendly-name";
         private const string PasswordParam = "password";
         private const string PrivateKeyOption = "private-key";
         private const string OutOption = "out";
@@ -38,6 +39,7 @@ namespace Certes.Cli.Commands
                 .DefineKeyOption()
                 .DefineOption(OutOption, help: Strings.HelpCertificateOut)
                 .DefineOption(PrivateKeyOption, help: Strings.HelpPrivateKey)
+                .DefineOption(FriendlyNameOption, help: Strings.HelpFriendlyName)
                 .DefineOption(IssuerOption, help: Strings.HelpCertificateIssuer)
                 .DefineUriParameter(OrderIdParam, help: Strings.HelpOrderId)
                 .DefineParameter(PasswordParam, help: Strings.HelpPfxPassword);
@@ -50,10 +52,15 @@ namespace Certes.Cli.Commands
             var keyPath = syntax.GetParameter<string>(PrivateKeyOption, true);
             var pwd = syntax.GetParameter<string>(PasswordParam, true);
             var issuer = syntax.GetParameter<string>(IssuerOption);
+            var friendlyName = syntax.GetParameter<string>(FriendlyNameOption);
             var (location, cert) = await DownloadCertificate(syntax);
 
-            var pfxName = string.Format(CultureInfo.InvariantCulture, "[certes] {0:yyyyMMddhhmmss}", DateTime.UtcNow);
             var privKey = await syntax.ReadKey(PrivateKeyOption, "CERTES_CERT_KEY", File, environment, true);
+            var pfxName = string.Format(CultureInfo.InvariantCulture, "[certes] {0:yyyyMMddhhmmss}", DateTime.UtcNow);
+            if (!string.IsNullOrWhiteSpace(friendlyName))
+            {
+                pfxName = string.Concat(friendlyName, " ", pfxName);
+            }
 
             var pfxBuilder = cert.ToPfx(privKey);
             if (!string.IsNullOrWhiteSpace(issuer))

--- a/src/Certes.Cli/Strings.Designer.cs
+++ b/src/Certes.Cli/Strings.Designer.cs
@@ -458,6 +458,15 @@ namespace Certes.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Friendly name for the certificate..
+        /// </summary>
+        internal static string HelpFriendlyName {
+            get {
+                return ResourceManager.GetString("HelpFriendlyName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path to the ACME account key..
         /// </summary>
         internal static string HelpKey {

--- a/src/Certes.Cli/Strings.resx
+++ b/src/Certes.Cli/Strings.resx
@@ -270,4 +270,7 @@
   <data name="HelpCertificateIssuer" xml:space="preserve">
     <value>Additional certificates for building the certificate chain.</value>
   </data>
+  <data name="HelpFriendlyName" xml:space="preserve">
+    <value>Friendly name for the certificate.</value>
+  </data>
 </root>

--- a/test/Certes.Tests/Cli/Commands/CertificatePfxCommandTests.cs
+++ b/test/Certes.Tests/Cli/Commands/CertificatePfxCommandTests.cs
@@ -85,7 +85,7 @@ namespace Certes.Cli.Commands
             var issuersPem = string.Join(Environment.NewLine, certChain.Issuers.Select(i => i.ToPem()));
             fileMock.Setup(m => m.ReadAllText("./issuers.pem")).ReturnsAsync(issuersPem);
 
-            syntax = DefineCommand($"pfx {orderLoc} --private-key {privateKeyPath} abcd1234 --out {outPath} --issuer ./issuers.pem");
+            syntax = DefineCommand($"pfx {orderLoc} --private-key {privateKeyPath} abcd1234 --out {outPath} --issuer ./issuers.pem --friendly-name friendly");
             ret = await cmd.Execute(syntax);
             fileMock.Verify(m => m.WriteAllBytes(outPath, It.IsAny<byte[]>()), Times.Once);
         }
@@ -93,12 +93,13 @@ namespace Certes.Cli.Commands
         [Fact]
         public void CanDefineCommand()
         {
-            var args = $"pfx http://acme.com/o/1 --private-key ./my-key.pem abcd1234 --server {LetsEncryptStagingV2} --issuer ./root-cert.pem";
+            var args = $"pfx http://acme.com/o/1 --private-key ./my-key.pem abcd1234 --server {LetsEncryptStagingV2} --issuer ./root-cert.pem --friendly-name friendly";
             var syntax = DefineCommand(args);
 
             Assert.Equal("pfx", syntax.ActiveCommand.Value);
             ValidateOption(syntax, "server", LetsEncryptStagingV2);
             ValidateOption(syntax, "issuer", "./root-cert.pem");
+            ValidateOption(syntax, "friendly-name", "friendly");
             ValidateParameter(syntax, "order-id", new Uri("http://acme.com/o/1"));
             ValidateParameter(syntax, "private-key", "./my-key.pem");
             ValidateParameter(syntax, "password", "abcd1234");


### PR DESCRIPTION
When you have a lot of different certificates that is generated with certes it is hard in the IIS manager to distinguish them and pick the correct one.
![image](https://user-images.githubusercontent.com/357589/42882074-c29f3a10-8a98-11e8-978a-59f8a6cf0648.png)

If we can add an additional `--friendly-name` parameter when we generate the PFX we can make it more user friendly to find correct certificate.
![image](https://user-images.githubusercontent.com/357589/42882198-ea71703a-8a98-11e8-9e65-e946418c0317.png)

See #145