### PR TITLE
Implement byte padding for Elliptic Curve point encoding as fix for #173

### DIFF
--- a/src/Certes/Crypto/AsymmetricCipherKey.cs
+++ b/src/Certes/Crypto/AsymmetricCipherKey.cs
@@ -10,22 +10,6 @@ namespace Certes.Crypto
 {
     internal class AsymmetricCipherKey : IKey
     {
-        private static byte[] PadBytes(byte[] bytes, int padding)
-        {
-            var remainder = padding - bytes.Length;
-
-            if (remainder <= 0)
-            {
-                return bytes;
-            }
-
-            var newArray = new byte[bytes.Length + remainder];
-
-            var startAt = newArray.Length - bytes.Length;
-            Array.Copy(bytes, 0, newArray, startAt, bytes.Length);
-            return newArray;
-        }
-
         public JsonWebKey JsonWebKey
         {
             get
@@ -49,19 +33,17 @@ namespace Certes.Crypto
 
                     // https://tools.ietf.org/html/rfc7518#section-6.2.1.2
                     // get the byte representation of the x & y coords on the Elliptic Curve,
-                    // then pad bytes to the required field length before encoding
+                    // with padding bytes to the required field length
 
-                    var xBytes = ecKey.Q.AffineXCoord.ToBigInteger().ToByteArrayUnsigned();
-                    var yBytes = ecKey.Q.AffineYCoord.ToBigInteger().ToByteArrayUnsigned();
-
-                    int requiredLength = ecKey.Parameters.Curve.FieldSize / 8;
+                    var xBytes = ecKey.Q.AffineXCoord.GetEncoded();
+                    var yBytes = ecKey.Q.AffineYCoord.GetEncoded();
 
                     return new EcJsonWebKey
                     {
                         KeyType = "EC",
                         Curve = curve,
-                        X = JwsConvert.ToBase64String(PadBytes(xBytes, requiredLength)),
-                        Y = JwsConvert.ToBase64String(PadBytes(yBytes, requiredLength))
+                        X = JwsConvert.ToBase64String(xBytes),
+                        Y = JwsConvert.ToBase64String(yBytes)
                     };
                 }
             }

--- a/src/Certes/Crypto/AsymmetricCipherKey.cs
+++ b/src/Certes/Crypto/AsymmetricCipherKey.cs
@@ -10,10 +10,14 @@ namespace Certes.Crypto
 {
     internal class AsymmetricCipherKey : IKey
     {
-        private byte[] PadBytes(byte[] bytes, int padding)
+        private static byte[] PadBytes(byte[] bytes, int padding)
         {
-            int remainder = padding - bytes.Length;
-            if (remainder <= 0) return bytes;
+            var remainder = padding - bytes.Length;
+
+            if (remainder <= 0)
+            {
+                return bytes;
+            }
 
             var newArray = new byte[bytes.Length + remainder];
 

--- a/src/Certes/Jws/EcJsonWebKey.cs
+++ b/src/Certes/Jws/EcJsonWebKey.cs
@@ -14,7 +14,7 @@ namespace Certes.Jws
         /// <value>
         /// The curve identifies the cryptographic curve used with the key.
         /// </value>
-        [JsonProperty("crv")]
+        [JsonProperty("crv", Order = 1)]
         internal string Curve { get; set; }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Certes.Jws
         /// <value>
         /// The x coordinate for the Elliptic Curve point.
         /// </value>
-        [JsonProperty("x")]
+        [JsonProperty("x", Order = 3)]
         internal string X { get; set; }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Certes.Jws
         /// <value>
         /// The y coordinate for the Elliptic Curve point.
         /// </value>
-        [JsonProperty("y")]
+        [JsonProperty("y", Order = 4)]
         internal string Y { get; set; }
     }
 }

--- a/src/Certes/Jws/JsonWebKey.cs
+++ b/src/Certes/Jws/JsonWebKey.cs
@@ -3,7 +3,8 @@
 namespace Certes.Jws
 {
     /// <summary>
-    /// Represents and JSON web key.
+    /// Represents and JSON web key. 
+    /// Note that inheriting classes must define JSON serialisation order to maintain lexographic order as per https://tools.ietf.org/html/rfc7638#page-8
     /// </summary>
     public class JsonWebKey
     {
@@ -13,7 +14,7 @@ namespace Certes.Jws
         /// <value>
         /// The type of the key.
         /// </value>
-        [JsonProperty("kty")]
+        [JsonProperty("kty", Order = 2)]
         internal string KeyType { get; set; }
     }
 }

--- a/src/Certes/Jws/RsaJsonWebKey.cs
+++ b/src/Certes/Jws/RsaJsonWebKey.cs
@@ -14,7 +14,7 @@ namespace Certes.Jws
         /// <value>
         /// The exponent value for the RSA public key.
         /// </value>
-        [JsonProperty("e")]
+        [JsonProperty("e", Order = 1)]
         internal string Exponent { get; set; }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Certes.Jws
         /// <value>
         /// The modulus value for the RSA public key.
         /// </value>
-        [JsonProperty("n")]
+        [JsonProperty("n", Order =3)]
         internal string Modulus { get; set; }
     }
 }

--- a/test/Certes.Tests/Crypto/SignatureKeyTests.cs
+++ b/test/Certes.Tests/Crypto/SignatureKeyTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Certes.Jws;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Certes.Crypto
@@ -30,6 +31,36 @@ namespace Certes.Crypto
             Assert.Equal(
                 JsonConvert.SerializeObject(key.JsonWebKey),
                 JsonConvert.SerializeObject(exported.JsonWebKey));
+        }
+
+        [Theory]
+        [InlineData(Keys.ES256Key)]
+        [InlineData(Keys.ES256Key_Alt1)]
+        [InlineData(Keys.ES384Key)]
+        [InlineData(Keys.ES512Key)]
+        private void CanEncodeJsonWebKey(string key)
+        {
+            var k = KeyFactory.FromPem(key);
+            var ecKey = (EcJsonWebKey)k.JsonWebKey;
+
+            Assert.Equal("EC", ecKey.KeyType);
+            Assert.Equal(ecKey.X.Length, ecKey.X.Length);
+        }
+
+        [Fact]
+        private void CanPadECCoordBytes()
+        {
+            var k = KeyFactory.FromPem(Keys.ES256Key_Alt1);
+            var ecKey = (EcJsonWebKey)k.JsonWebKey;
+
+            Assert.Equal("AJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68E", ecKey.X);
+            Assert.Equal("vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs", ecKey.Y);
+
+            k = KeyFactory.FromPem(Keys.ES256Key);
+            ecKey = (EcJsonWebKey)k.JsonWebKey;
+
+            Assert.Equal("dHVy6M_8l7UibLdFPlhnbdNv-LROnx6_FcdyFArBd_s", ecKey.X);
+            Assert.Equal("2xBzsnlAASQN0jQYuxdWybSzEQtsxoT-z7XGIDp0k_c", ecKey.Y);
         }
     }
 }

--- a/test/Certes.Tests/Crypto/SignatureKeyTests.cs
+++ b/test/Certes.Tests/Crypto/SignatureKeyTests.cs
@@ -62,5 +62,32 @@ namespace Certes.Crypto
             Assert.Equal("dHVy6M_8l7UibLdFPlhnbdNv-LROnx6_FcdyFArBd_s", ecKey.X);
             Assert.Equal("2xBzsnlAASQN0jQYuxdWybSzEQtsxoT-z7XGIDp0k_c", ecKey.Y);
         }
+
+        [Fact]
+        private void EnsurePropertySerializationOrder()
+        {
+            /// https://tools.ietf.org/html/rfc7638#page-8
+            /// The lexographical (alphabetical) order of the serialized key is important for JWK thumprint validation
+            /// without a specified order this order can vary across platforms during property reflection.
+
+            var k = KeyFactory.FromPem(Keys.ES256Key_Alt1);
+            var ecKey = (EcJsonWebKey)k.JsonWebKey;
+            var ecKeyJson = JsonConvert.SerializeObject(ecKey, Formatting.None);
+
+            Assert.Equal(
+                "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"AJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68E\",\"y\":\"vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs\"}"
+                , ecKeyJson
+                );
+
+            k = KeyFactory.FromPem(Keys.RS256Key);
+            var rsaKey = (RsaJsonWebKey)k.JsonWebKey;
+            var rsaKeyJson = JsonConvert.SerializeObject(rsaKey, Formatting.None);
+
+            Assert.Equal(
+                "{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"maeT6EsXTVHAdwuq3IlAl9uljXE5CnkRpr6uSw_Fk9nQshfZqKFdeZHkSBvIaLirE2ZidMEYy-rpS1O2j-viTG5U6bUSWo8aoeKoXwYfwbXNboEA-P4HgGCjD22XaXAkBHdhgyZ0UBX2z-jCx1smd7nucsi4h4RhC_2cEB1x_mE6XS5VlpvG91Hbcgml4cl0NZrWPtJ4DhFdPNUtQ8q3AYXkOr_OSFZgRKjesRaqfnSdJNABqlO_jEzAx0fgJfPZe1WlRWOfGRVBVopZ4_N5HpR_9lsNDzCZyidFsHwzvpkP6R6HbS8CMrNWgtkTbnz27EVqIhkYdiPVIN2Xkwj0BQ\"}"
+                ,
+                rsaKeyJson
+                );
+        }
     }
 }

--- a/test/Certes.Tests/Keys.cs
+++ b/test/Certes.Tests/Keys.cs
@@ -1,4 +1,4 @@
-﻿namespace Certes
+namespace Certes
 {
     public static class Keys
     {
@@ -34,6 +34,13 @@ qeIAldJH4zaLqkEXH/643NjLFeQy7w4cbdODASwGqBEJa9SJJjMfbw==
         internal const string ES256Key = @"-----BEGIN EC PRIVATE KEY-----
 MDECAQEEIJTKjLb/7vi68uMaaktLL8A8uKeM5r2ibBJm1KPG/xhVoAoGCCqGSM49
 AwEH
+-----END EC PRIVATE KEY-----";
+
+        // Special case: X coord of EC point is a 31 bytes instead of 32 and requires padding before encoding
+        internal const string ES256Key_Alt1 = @"-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIDWajU0PyhYKeulfy/luNtkAve7DkwQ01bXJ97zbxB66oAoGCCqGSM49
+AwEHoUQDQgAEAJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68G8QSzhXR6A
+mQ3IzZDimnTTXO7XhVylDT8SLzE44/Epmw==
 -----END EC PRIVATE KEY-----";
 
         internal const string ES384Key = @"-----BEGIN EC PRIVATE KEY-----


### PR DESCRIPTION
## Description

This change implements byte padding of Elliptic Curve point byte representations to match the required field size.

## Checklist

- [X ] All tests are passing
- [ X] New tests were created to address changes in pr (and tests are passing)
- [X ] Updated README and/or documentation, if necessary

