### PR TITLE
Fix json order being ignored due to custom ContractResolver

### DIFF
--- a/src/Certes/Json/JsonUtil.cs
+++ b/src/Certes/Json/JsonUtil.cs
@@ -21,7 +21,6 @@ namespace Certes.Json
         {
             var jsonSettings = new JsonSerializerSettings
             {
-                ContractResolver = new ContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore,
                 MissingMemberHandling = MissingMemberHandling.Ignore
             };

--- a/src/Certes/Json/JsonUtil.cs
+++ b/src/Certes/Json/JsonUtil.cs
@@ -21,6 +21,9 @@ namespace Certes.Json
         {
             var jsonSettings = new JsonSerializerSettings
             {
+                ContractResolver = new DefaultContractResolver {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                },
                 NullValueHandling = NullValueHandling.Ignore,
                 MissingMemberHandling = MissingMemberHandling.Ignore
             };

--- a/test/Certes.Tests/Crypto/SignatureKeyTests.cs
+++ b/test/Certes.Tests/Crypto/SignatureKeyTests.cs
@@ -1,4 +1,5 @@
-﻿using Certes.Jws;
+﻿using Certes.Json;
+using Certes.Jws;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -72,7 +73,7 @@ namespace Certes.Crypto
 
             var k = KeyFactory.FromPem(Keys.ES256Key_Alt1);
             var ecKey = (EcJsonWebKey)k.JsonWebKey;
-            var ecKeyJson = JsonConvert.SerializeObject(ecKey, Formatting.None);
+            var ecKeyJson = JsonConvert.SerializeObject(ecKey, Formatting.None, JsonUtil.CreateSettings());
 
             Assert.Equal(
                 "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"AJz0yAAXAwEmOhTRkjXxwgedbWO6gobYM3lWszrS68E\",\"y\":\"vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs\"}"
@@ -81,7 +82,7 @@ namespace Certes.Crypto
 
             k = KeyFactory.FromPem(Keys.RS256Key);
             var rsaKey = (RsaJsonWebKey)k.JsonWebKey;
-            var rsaKeyJson = JsonConvert.SerializeObject(rsaKey, Formatting.None);
+            var rsaKeyJson = JsonConvert.SerializeObject(rsaKey, Formatting.None, JsonUtil.CreateSettings());
 
             Assert.Equal(
                 "{\"e\":\"AQAB\",\"kty\":\"RSA\",\"n\":\"maeT6EsXTVHAdwuq3IlAl9uljXE5CnkRpr6uSw_Fk9nQshfZqKFdeZHkSBvIaLirE2ZidMEYy-rpS1O2j-viTG5U6bUSWo8aoeKoXwYfwbXNboEA-P4HgGCjD22XaXAkBHdhgyZ0UBX2z-jCx1smd7nucsi4h4RhC_2cEB1x_mE6XS5VlpvG91Hbcgml4cl0NZrWPtJ4DhFdPNUtQ8q3AYXkOr_OSFZgRKjesRaqfnSdJNABqlO_jEzAx0fgJfPZe1WlRWOfGRVBVopZ4_N5HpR_9lsNDzCZyidFsHwzvpkP6R6HbS8CMrNWgtkTbnz27EVqIhkYdiPVIN2Xkwj0BQ\"}"


### PR DESCRIPTION
## Description

In some regions (such as Latvian) the default sort order of reflected properties are different while serializing to JSON. PR #174 partly addressed this order issue for account key serialization but neglected to test the custom JsonSerializerSettings used when actually creating key Thumbprints, which in turn overrides the ContractResolver and ignores the explicit json property order attribute in the JsonWebKey objects. This change ~~removes~~ replaces the custom ContractResolver (so that the default will be used, with added camelCasing as the default).

## Checklist

- [X] All tests are passing
- [X] New tests were created to address changes in pr (and tests are passing)
- [X] Updated README and/or documentation, if necessary
