### PR TITLE
Made the password optional for PFX builds

### DIFF
--- a/src/Certes/Pkcs/PfxBuilder.cs
+++ b/src/Certes/Pkcs/PfxBuilder.cs
@@ -71,7 +71,7 @@ namespace Certes.Pkcs
         /// <param name="friendlyName">The friendly name.</param>
         /// <param name="password">The password.</param>
         /// <returns>The PFX data.</returns>
-        public byte[] Build(string friendlyName, string password)
+        public byte[] Build(string friendlyName, string password = null)
         {
             var keyPair = LoadKeyPair();
             var store = new Pkcs12StoreBuilder().Build();
@@ -94,7 +94,7 @@ namespace Certes.Pkcs
 
             using (var buffer = new MemoryStream())
             {
-                store.Save(buffer, password.ToCharArray(), new SecureRandom());
+                store.Save(buffer, password?.ToCharArray(), new SecureRandom());
                 return buffer.ToArray();
             }
         }

--- a/test/Certes.Tests/Pkcs/PfxBuilderTests.cs
+++ b/test/Certes.Tests/Pkcs/PfxBuilderTests.cs
@@ -28,6 +28,21 @@ namespace Certes.Pkcs
         [InlineData(KeyAlgorithm.ES256)]
         [InlineData(KeyAlgorithm.ES384)]
         [InlineData(KeyAlgorithm.ES512)]
+        public async Task CanCreatePfxChainWithNoPassword(KeyAlgorithm alog)
+        {
+            var (cert, key) = await Helper.GetValidCert();
+
+            var pfxBuilder = new PfxBuilder(
+                Encoding.UTF8.GetBytes(cert), KeyFactory.NewKey(alog));
+            pfxBuilder.AddIssuers(Encoding.UTF8.GetBytes(cert));
+            var pfx = pfxBuilder.Build("my-cert");
+        }
+
+        [Theory]
+        [InlineData(KeyAlgorithm.RS256)]
+        [InlineData(KeyAlgorithm.ES256)]
+        [InlineData(KeyAlgorithm.ES384)]
+        [InlineData(KeyAlgorithm.ES512)]
         public void CanCreatePfxWithoutChain(KeyAlgorithm alog)
         {
             var leafCert = File.ReadAllText("./Data/leaf-cert.pem");
@@ -36,6 +51,21 @@ namespace Certes.Pkcs
                 Encoding.UTF8.GetBytes(leafCert), KeyFactory.NewKey(alog));
             pfxBuilder.FullChain = false;
             var pfx = pfxBuilder.Build("my-cert", "abcd1234");
+        }
+
+        [Theory]
+        [InlineData(KeyAlgorithm.RS256)]
+        [InlineData(KeyAlgorithm.ES256)]
+        [InlineData(KeyAlgorithm.ES384)]
+        [InlineData(KeyAlgorithm.ES512)]
+        public void CanCreatePfxWithoutChainAndNoPassword(KeyAlgorithm alog)
+        {
+            var leafCert = File.ReadAllText("./Data/leaf-cert.pem");
+
+            var pfxBuilder = new PfxBuilder(
+                Encoding.UTF8.GetBytes(leafCert), KeyFactory.NewKey(alog));
+            pfxBuilder.FullChain = false;
+            var pfx = pfxBuilder.Build("my-cert");
         }
     }
 }


### PR DESCRIPTION
## Description

It's a small change that allows the creation of PFX certificates without a password.

## Checklist

- [x ] All tests are passing
- [x ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary
