### PR TITLE
Implement custom UserAgent http header for Certes (#189)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Implement custom UserAgent http header for Certes [#189](https://github.com/fszlin/certes/issues/189)
 
 ## [2.3.3] - 2018-12-16
 ### Changed

--- a/src/Certes/Acme/AcmeHttpClient.cs
+++ b/src/Certes/Acme/AcmeHttpClient.cs
@@ -20,7 +20,7 @@ namespace Certes.Acme
         private const string MimeJoseJson = "application/jose+json";
 
         private readonly static JsonSerializerSettings jsonSettings = JsonUtil.CreateSettings();
-        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(() => new HttpClient());
+        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(()=>HttpClientFactory.CreateInternalHttpClient());
         private readonly Lazy<HttpClient> http;
 
         private Uri newNonceUri;

--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -19,7 +19,7 @@ namespace Certes.Acme
     {
         private const string MimeJson = "application/json";
 
-        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(() => new HttpClient());
+        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(()=>HttpClientFactory.CreateInternalHttpClient());
         private readonly HttpClient http;
         private readonly Uri serverUri;
         private readonly bool shouldDisposeHttp;

--- a/src/Certes/Acme/AcmeUserAgentHandler.cs
+++ b/src/Certes/Acme/AcmeUserAgentHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Certes.Acme
+{
+    internal class AcmeUserAgentHandler : DelegatingHandler
+    {
+        static readonly ProductInfoHeaderValue certesVersionUserAgentHeader = new ProductInfoHeaderValue("Certes", typeof(AcmeUserAgentHandler).GetTypeInfo().Assembly.GetName().Version.ToString());
+        static readonly ProductInfoHeaderValue acmeVersionUserAgentHeader = new ProductInfoHeaderValue("(ACME 2.0)");
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.UserAgent.Clear();
+            request.Headers.UserAgent.Add(certesVersionUserAgentHeader);
+            request.Headers.UserAgent.Add(acmeVersionUserAgentHeader);
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Certes/Acme/HttpClientFactory.cs
+++ b/src/Certes/Acme/HttpClientFactory.cs
@@ -1,0 +1,23 @@
+﻿using System.Net.Http;
+
+namespace Certes.Acme
+{
+    internal static class HttpClientFactory
+    {
+        public static HttpClient CreateInternalHttpClient(HttpMessageHandler httpMessageHandler = null)
+        {
+            var handler = new AcmeUserAgentHandler();
+
+            if(httpMessageHandler!=null)
+            {
+                handler.InnerHandler = httpMessageHandler;
+            }
+            else
+            {
+                handler.InnerHandler = new HttpClientHandler();
+            }
+
+            return new HttpClient(handler, true);
+        }
+    }
+}

--- a/test/Certes.Tests/Acme/AcmeUserAgentHandlerTests.cs
+++ b/test/Certes.Tests/Acme/AcmeUserAgentHandlerTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Certes.Acme
+{
+    public class AcmeUserAgentHandlerTests
+    {
+        [Fact]
+        public async Task UserAgentSetByHandler()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns((HttpRequestMessage request, CancellationToken __) =>
+                {                    
+                    Assert.True(request.Headers.UserAgent.Count > 1);
+                    Assert.Equal("Certes",request.Headers.UserAgent.FirstOrDefault()?.Product.Name);
+                    Assert.Equal(typeof(AcmeUserAgentHandler).GetTypeInfo().Assembly.GetName().Version.ToString(), request.Headers.UserAgent.FirstOrDefault()?.Product.Version);
+                    Assert.Equal("(ACME 2.0)", request.Headers.UserAgent.Skip(1).FirstOrDefault()?.Comment);
+
+                    var resp = new HttpResponseMessage();
+                    resp.StatusCode = HttpStatusCode.OK;                    
+                    return Task.FromResult(resp);
+                }).Verifiable();
+
+            var client = HttpClientFactory.CreateInternalHttpClient(handlerMock.Object);
+            await client.GetAsync("http://acme.d/directory");            
+        }
+    }    
+}


### PR DESCRIPTION
## Description

Implement custom UserAgent http header for Certes (#189)
UserAgent header has format: Certes\{libversion} (ACME 2.0)

## Checklist

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
- [x] Updated README and/or documentation, if necessary

