### PR TITLE
Add HTTP-01 key authorization to CLI output

### DIFF
--- a/src/Certes.Cli/Commands/OrderAuthzCommand.cs
+++ b/src/Certes.Cli/Commands/OrderAuthzCommand.cs
@@ -78,6 +78,7 @@ namespace Certes.Cli.Commands
             {
                 location = challengeCtx.Location,
                 resource = challenge,
+                keyAuthz = challengeCtx.KeyAuthz
             };
         }
     }

--- a/test/Certes.Tests/Cli/Commands/OrderAuthzCommandTests.cs
+++ b/test/Certes.Tests/Cli/Commands/OrderAuthzCommandTests.cs
@@ -58,6 +58,7 @@ namespace Certes.Cli.Commands
             challengeMock1.SetupGet(m => m.Location).Returns(challenge1Loc);
             challengeMock1.SetupGet(m => m.Type).Returns(ChallengeTypes.Http01);
             challengeMock1.Setup(m => m.Resource()).ReturnsAsync(authz.Challenges[0]);
+            challengeMock1.Setup(m => m.KeyAuthz).Returns(GetKeyV2().KeyAuthorization("http-token"));
             var challengeMock2 = new Mock<IChallengeContext>(MockBehavior.Strict);
             challengeMock2.SetupGet(m => m.Location).Returns(challenge2Loc);
             challengeMock2.SetupGet(m => m.Type).Returns(ChallengeTypes.Dns01);
@@ -87,6 +88,7 @@ namespace Certes.Cli.Commands
                 {
                     location = challenge1Loc,
                     resource = authz.Challenges[0],
+                    keyAuthz = GetKeyV2().KeyAuthorization("http-token"),
                 }),
                 JsonConvert.SerializeObject(ret));
 


### PR DESCRIPTION
## Description

The only thing the CLI needs to get [HTTP-01 challenges][1] to work is a key authorization. I added the key authorization text to the CLI output. Output now looks like this:

```
{
  "location": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/123/456",
  "resource": {
    "type": "http-01",
    "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/123/456",
    "status": "Pending",
    "token": "[TOKEN]"
  },
  "keyAuthz": "[TOKEN].[ACCOUNT_FINGERPRINT]"
}
```

Some day perhaps it would be nice to add a `--wwwroot` parameter to the CLI, and then it could automatically create the key authorization file in the correct location.

## Checklist

- [x] All tests are passing
- [x] <strike>New tests were created</strike> Existing tests modified to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

[1]: https://letsencrypt.org/docs/challenge-types/#http-01-challenge