### PR TITLE
Add user-agent header to HTTP requests

### DIFF
--- a/src/Certes/Acme/AcmeHttpHandler.cs
+++ b/src/Certes/Acme/AcmeHttpHandler.cs
@@ -19,7 +19,7 @@ namespace Certes.Acme
     {
         private const string MimeJson = "application/json";
 
-        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(() => new HttpClient());
+        private readonly static Lazy<HttpClient> SharedHttp = new Lazy<HttpClient>(AcmeHttpClient.CreateHttpClient);
         private readonly HttpClient http;
         private readonly Uri serverUri;
         private readonly bool shouldDisposeHttp;

--- a/test/Certes.Tests/Acme/AcmeHttpClientTests.cs
+++ b/test/Certes.Tests/Acme/AcmeHttpClientTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +18,7 @@ namespace Certes.Acme
         {
             private readonly JsonSerializerSettings jsonSettings = JsonUtil.CreateSettings();
 
-            public bool SendNonce { get;set; } = true;
+            public bool SendNonce { get; set; } = true;
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
@@ -61,5 +63,21 @@ namespace Certes.Acme
             }
         }
 
+        [Fact]
+        public void SetsUserAgent()
+        {
+            bool IsCertes(ProductInfoHeaderValue header)
+            {
+                return header.Product.Name == "Certes" 
+                    && header.Product.Version == typeof(AcmeHttpClient).GetTypeInfo().Assembly.GetName().Version.ToString();
+            }
+
+            Assert.Contains(AcmeHttpClient.CreateHttpClient().DefaultRequestHeaders.UserAgent, IsCertes);
+
+            var httpClient = new HttpClient();
+            var acmeClient = new AcmeHttpClient(new Uri("https://acme.d/directory"), httpClient);
+
+            Assert.Contains(httpClient.DefaultRequestHeaders.UserAgent, IsCertes);
+        }
     }
 }


### PR DESCRIPTION
Resolves #203

## Description

Per the request from Let's Encrypt engineers in #203, this adds the User-Agent request header to the Acme client code.

## Checklist

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
- [x] Updated README and/or documentation, if necessary

