### PR TITLE
HTTP-01 CLI challenge fix

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -125,7 +125,7 @@ The output will contain the two value fields we need to use for order validation
 
 ```json
 {
-  "location": ...,
+  "location": "...",
   "resource": {
     "type": "http-01",
     "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/2645311522/sample",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -129,7 +129,7 @@ The output will contain the `TXT` record value.
   "dnsTxt": "Uil-TOCuvR9qnC7H3V65ossmqPgDERDg_9ahr6ZYBd0",
   "resource": "..."
 }
-
+```
 <!--
 TODO: TLS-ALPN-01
 -->

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,7 +42,7 @@ The result should look similar to this:
       "mailto:email@example.com"
     ]
   }
-}
+
 ```
 
 ## Ordering SSL Certificates
@@ -121,15 +121,22 @@ The output will contain the `TXT` record value.
  ```Powershell
 certes order authz https://acme-v02.api.letsencrypt.org/acme/order/2/3 api.example.com http
 ```
-The output will contain the `TXT` record value.
+The output will contain the two value fields we need to use for order validation.
 
 ```json
 {
-  "...": "...",
-  "dnsTxt": "Uil-TOCuvR9qnC7H3V65ossmqPgDERDg_9ahr6ZYBd0",
-  "resource": "..."
+  "location": ...,
+  "resource": {
+    "type": "http-01",
+    "url": "https://acme-v02.api.letsencrypt.org/acme/chall-v3/2645311522/sample",
+    "status": "Pending",
+    "token": "iuaJR4CdLFxvt4RsmVsgfSU46rqYsrQpzxasdactest"
+  },
+  "keyAuthz": "iuaJR4CdLFxvt4RsmVsgfSU46rqYsrQpzxasdactest.Qed9-4Ek4ot3idslj89tmCMGEYlfY5I463X37hCd9i4"
 }
 ```
+
+On your application server you need to create file which will be available under *http://api.example.com/.well-known/acme-challenge/iuaJR4CdLFxvt4RsmVsgfSU46rqYsrQpzxasdactest* (resource.token value for last url segment). File content needs to be set as *iuaJR4CdLFxvt4RsmVsgfSU46rqYsrQpzxasdactest.Qed9-4Ek4ot3idslj89tmCMGEYlfY5I463X37hCd9i4* (keyAuthz value).
 <!--
 TODO: TLS-ALPN-01
 -->

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -96,7 +96,10 @@ can fullfill any one of them.
 ### Setup for Challenges
 
 Certes CLI provides commands for generating necessary data to fullfill
-the challenges. To get the `TXT` record value for `DNS` challenge:
+the challenges.
+
+#### DNS challenge
+ To get the `TXT` record value for `DNS` challenge:
 
 ```Powershell
 certes order authz https://acme-v02.api.letsencrypt.org/acme/order/2/3 *.example.com dns
@@ -112,8 +115,23 @@ The output will contain the `TXT` record value.
 }
 ```
 
+#### HTTP-01 challenge
+ To get token and thumbprint value for `HTTP-01` challenge:
+
+ ```Powershell
+certes order authz https://acme-v02.api.letsencrypt.org/acme/order/2/3 api.example.com http
+```
+The output will contain the `TXT` record value.
+
+```json
+{
+  "...": "...",
+  "dnsTxt": "Uil-TOCuvR9qnC7H3V65ossmqPgDERDg_9ahr6ZYBd0",
+  "resource": "..."
+}
+
 <!--
-TODO: HTTP-01 and TLS-ALPN-01
+TODO: TLS-ALPN-01
 -->
 
 ### Configure DNS challenge on Azure DNS

--- a/src/Certes.Cli/Commands/OrderAuthzCommand.cs
+++ b/src/Certes.Cli/Commands/OrderAuthzCommand.cs
@@ -78,6 +78,7 @@ namespace Certes.Cli.Commands
             {
                 location = challengeCtx.Location,
                 resource = challenge,
+                keyAuthz = challengeCtx.KeyAuthz
             };
         }
     }

--- a/test/Certes.Tests/Cli/Commands/OrderAuthzCommandTests.cs
+++ b/test/Certes.Tests/Cli/Commands/OrderAuthzCommandTests.cs
@@ -47,8 +47,9 @@ namespace Certes.Cli.Commands
                         Token = "dns-token",
                         Type = ChallengeTypes.Dns01,
                     }
-                }
+                }                
             };
+            var http01KeyAuthzThumbprint = "keyAuthz";
 
             var settingsMock = new Mock<IUserSettings>(MockBehavior.Strict);
             settingsMock.Setup(m => m.GetDefaultServer()).ReturnsAsync(LetsEncryptV2);
@@ -57,6 +58,7 @@ namespace Certes.Cli.Commands
             var challengeMock1 = new Mock<IChallengeContext>(MockBehavior.Strict);
             challengeMock1.SetupGet(m => m.Location).Returns(challenge1Loc);
             challengeMock1.SetupGet(m => m.Type).Returns(ChallengeTypes.Http01);
+            challengeMock1.SetupGet(m => m.KeyAuthz).Returns(http01KeyAuthzThumbprint);
             challengeMock1.Setup(m => m.Resource()).ReturnsAsync(authz.Challenges[0]);
             var challengeMock2 = new Mock<IChallengeContext>(MockBehavior.Strict);
             challengeMock2.SetupGet(m => m.Location).Returns(challenge2Loc);
@@ -87,6 +89,7 @@ namespace Certes.Cli.Commands
                 {
                     location = challenge1Loc,
                     resource = authz.Challenges[0],
+                    keyAuthz = http01KeyAuthzThumbprint
                 }),
                 JsonConvert.SerializeObject(ret));
 


### PR DESCRIPTION
## Description

Adding missing keyAuthz value into authz response required to properly validate HTTP-01 challenge request.

## Checklist

- [x] All tests are passing
- [x] New tests were created to address changes in pr (and tests are passing)
- [x] Updated README and/or documentation, if necessary

Thanks for contributing!
