### PR TITLE
Allow reading PEM's with an AsymmetricCipherKeyPair.

### DIFF
--- a/src/Certes/Crypto/KeyAlgorithmProvider.cs
+++ b/src/Certes/Crypto/KeyAlgorithmProvider.cs
@@ -28,8 +28,16 @@ namespace Certes.Crypto
             using (var reader = new StringReader(pem))
             {
                 var pemReader = new PemReader(reader);
-                var pemKey = pemReader.ReadObject() as AsymmetricCipherKeyPair;
-                return ReadKey(pemKey.Private);
+                var untyped = pemReader.ReadObject();
+                switch(untyped)
+                {
+                    case AsymmetricCipherKeyPair keyPair:
+                        return ReadKey(keyPair.Private);
+                    case AsymmetricKeyParameter keyParam:
+                        return ReadKey(keyParam);
+                    default:
+                        throw new NotSupportedException();
+                }
             }
         }
 

--- a/src/Certes/Pkcs/CertificationRequestBuilder.cs
+++ b/src/Certes/Pkcs/CertificationRequestBuilder.cs
@@ -152,7 +152,13 @@ namespace Certes.Pkcs
             };
         }
 
-        private Pkcs10CertificationRequest GeneratePkcs10()
+        /// <summary>
+        /// Generates the CSR.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Pkcs10CertificationRequest"/>.
+        /// </returns>
+        public Pkcs10CertificationRequest GeneratePkcs10()
         {
             var x509 = new X509Name(attributes.Select(p => p.Id).ToArray(), attributes.Select(p => p.Value).ToArray());
 

--- a/src/Certes/Pkcs/CertificationRequestBuilder.cs
+++ b/src/Certes/Pkcs/CertificationRequestBuilder.cs
@@ -152,13 +152,7 @@ namespace Certes.Pkcs
             };
         }
 
-        /// <summary>
-        /// Generates the CSR.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="Pkcs10CertificationRequest"/>.
-        /// </returns>
-        public Pkcs10CertificationRequest GeneratePkcs10()
+        private Pkcs10CertificationRequest GeneratePkcs10()
         {
             var x509 = new X509Name(attributes.Select(p => p.Id).ToArray(), attributes.Select(p => p.Value).ToArray());
 


### PR DESCRIPTION
A few minor changes which fix blocking issues using Certes to generate certificates using files from 'Crypt-LE'. This will:

* Allow `KeyAlgorithmProvider.GetKey(string pem)` to work if the `PemReader.ReadObject()` returns an `AsymmetricKeyParameter` instead of a `AsymmetricCipherKeyPair`.
* DELETED: Enable public access to the actual `Pkcs10CertificationRequest` which `CertificationRequestBuilder` uses internally.