### PR TITLE
Implement optional keySize for RSA keys (Fix #225)

### DIFF
--- a/src/Certes/Crypto/EllipticCurveAlgorithm.cs
+++ b/src/Certes/Crypto/EllipticCurveAlgorithm.cs
@@ -32,7 +32,7 @@ namespace Certes.Crypto
 
         public ISigner CreateSigner(IKey key) => new EllipticCurveSigner(key, signingAlgorithm, hashAlgorithm);
 
-        public IKey GenerateKey()
+        public IKey GenerateKey(int? keySize = null)
         {
             var generator = GeneratorUtilities.GetKeyPairGenerator("ECDSA");
             var generatorParams = new ECKeyGenerationParameters(

--- a/src/Certes/Crypto/IKeyAlgorithm.cs
+++ b/src/Certes/Crypto/IKeyAlgorithm.cs
@@ -3,6 +3,6 @@
     internal interface IKeyAlgorithm
     {
         ISigner CreateSigner(IKey keyPair);
-        IKey GenerateKey();
+        IKey GenerateKey(int? keySize = null);
     }
 }

--- a/src/Certes/Crypto/RS256Algorithm.cs
+++ b/src/Certes/Crypto/RS256Algorithm.cs
@@ -8,13 +8,19 @@ namespace Certes.Crypto
     {
         public ISigner CreateSigner(IKey key) => new RS256Signer(key);
 
-        public IKey GenerateKey()
+        public IKey GenerateKey(int? keySize)
         {
+            if (keySize==null)
+            {
+                keySize = 2048;
+            }
+
             var generator = GeneratorUtilities.GetKeyPairGenerator("RSA");
-            var generatorParams = new RsaKeyGenerationParameters(
-                BigInteger.ValueOf(0x10001), new SecureRandom(), 2048, 128);
+            var generatorParams = new RsaKeyGenerationParameters(BigInteger.ValueOf(0x10001), new SecureRandom(), (int)keySize, 128);
             generator.Init(generatorParams);
+
             var keyPair = generator.GenerateKeyPair();
+
             return new AsymmetricCipherKey(KeyAlgorithm.RS256, keyPair);
         }
     }

--- a/src/Certes/KeyFactory.cs
+++ b/src/Certes/KeyFactory.cs
@@ -13,11 +13,12 @@ namespace Certes
         /// Creates a random key.
         /// </summary>
         /// <param name="algorithm">The algorithm to use.</param>
+        /// <param name="keySize">Optional key size (used for RSA, defaults to 2048)</param>
         /// <returns>The key created.</returns>
-        public static IKey NewKey(KeyAlgorithm algorithm)
+        public static IKey NewKey(KeyAlgorithm algorithm, int? keySize = null)
         {
             var algo = keyAlgorithmProvider.Get(algorithm);
-            return algo.GenerateKey();
+            return algo.GenerateKey(keySize);
         }
 
         /// <summary>

--- a/test/Certes.Tests/Crypto/KeyAlgorithmProviderTests.cs
+++ b/test/Certes.Tests/Crypto/KeyAlgorithmProviderTests.cs
@@ -37,15 +37,18 @@ namespace Certes.Crypto
         }
 
         [Theory]
-        [InlineData(KeyAlgorithm.RS256)]
+        [InlineData(KeyAlgorithm.RS256, null)]
+        [InlineData(KeyAlgorithm.RS256, 2048)]
+        [InlineData(KeyAlgorithm.RS256, 3072)]
+        [InlineData(KeyAlgorithm.RS256, 4096)]
         [InlineData(KeyAlgorithm.ES256)]
         [InlineData(KeyAlgorithm.ES384)]
         [InlineData(KeyAlgorithm.ES512)]
-        public void CanGetKey(KeyAlgorithm algorithm)
+        public void CanGetKey(KeyAlgorithm algorithm, int? keySize = null)
         {
             var provider = new KeyAlgorithmProvider();
             var algo = provider.Get(algorithm);
-            var key = (AsymmetricCipherKey)algo.GenerateKey();
+            var key = (AsymmetricCipherKey)algo.GenerateKey(keySize);
 
             var keyData = key.ToDer();
 


### PR DESCRIPTION
## Description

This PR adds an optional keySize parameter for use with RSA keys. If not specified the default remains 2048. For Elliptic Curve keys with parameter does nothing. 

## Checklist

- [X ] All tests are passing
- [X] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
