### PR TITLE
Update prefferedChain now checks the root CA instead of any Issuer

### DIFF
--- a/src/Certes/Acme/CertificateChain.cs
+++ b/src/Certes/Acme/CertificateChain.cs
@@ -54,15 +54,10 @@ namespace Certes.Acme
 
             var certParser = new X509CertificateParser();
             var allcerts = Issuers.Select(x => x.ToPem()).ToList();
-            allcerts.Insert(0, Certificate.ToPem());
-            foreach (var pem in allcerts)
-            {
-                var cert = certParser.ReadCertificate(Encoding.UTF8.GetBytes(pem));
-                if (cert.IssuerDN.GetValueList().Contains(preferredChain))
-                    return true;
-            }
 
-            return false;
+            var cert = certParser.ReadCertificate(Encoding.UTF8.GetBytes(allcerts.Last()));
+
+            return cert.SubjectDN.GetValueList().Contains(preferredChain) && cert.IssuerDN.GetValueList().Contains(preferredChain);
         }
     }
 


### PR DESCRIPTION
certes still returns the "DST Root CA X3" certfiicate chain, even with the argument "preferredChain" set to "ISRG Root X1". Cause of the problem is, that an intermediate certificate of the "DST Root CA X3" chain is issued by "ISRG Root X1" and certes checks if any issuer in this chain contains the name.

To fix this, the method "MatchesPreferredChain" now checks if the SubjectDN and Issuer of the last certficate in the chain matches the value of "prefferedChain".