### PR TITLE
let PfxBuilder support setting the Cert Algorithm of PFX

### DIFF
--- a/src/Certes/Pkcs/PfxBuilder.cs
+++ b/src/Certes/Pkcs/PfxBuilder.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using Certes.Crypto;
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Pkix;

--- a/src/Certes/Pkcs/PfxBuilder.cs
+++ b/src/Certes/Pkcs/PfxBuilder.cs
@@ -70,11 +70,14 @@ namespace Certes.Pkcs
         /// </summary>
         /// <param name="friendlyName">The friendly name.</param>
         /// <param name="password">The password.</param>
+        /// <param name="certAlgorithm">The Cert Algorithm</param>
         /// <returns>The PFX data.</returns>
-        public byte[] Build(string friendlyName, string password)
+        public byte[] Build(string friendlyName, string password, DerObjectIdentifier certAlgorithm = null)
         {
             var keyPair = LoadKeyPair();
-            var store = new Pkcs12StoreBuilder().Build();
+            var builder = new Pkcs12StoreBuilder();
+            if(certAlgorithm!=null) builder.SetCertAlgorithm(certAlgorithm);
+            var store = builder.Build();
 
             var entry = new X509CertificateEntry(certificate);
             store.SetCertificateEntry(friendlyName, entry);


### PR DESCRIPTION
## Description

The default Cert Algorithm of Org.BouncyCastle.Pkcs.Pkcs12StoreBuilder is PkcsObjectIdentifiers.PbewithShaAnd40BitRC2Cbc

Android devices do not support RC2's pfx certificate by default, so the modified method here passes the Cert Algorithm into the custom Cert Algorithm of the exported PFX file.

For example: pfxBuilder.Build(friendlyName, pfxPassword, PkcsObjectIdentifiers.PbeWithShaAnd3KeyTripleDesCbc)

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
