### PR TITLE
Change BouncyCastle library from Portable.BouncyCastle to BouncyCastl…

### DIFF
--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 

--- a/src/Certes/Pkcs/PfxBuilder.cs
+++ b/src/Certes/Pkcs/PfxBuilder.cs
@@ -111,7 +111,7 @@ namespace Certes.Pkcs
                     Cert = cert
                 });
 
-            var rootCerts = new HashSet(certificates.Where(c => c.IsRoot).Select(c => new TrustAnchor(c.Cert, null)));
+            var rootCerts = new HashSet<TrustAnchor>(certificates.Where(c => c.IsRoot).Select(c => new TrustAnchor(c.Cert, null)));
             var intermediateCerts = certificates.Where(c => !c.IsRoot).Select(c => c.Cert).ToList();
             intermediateCerts.Add(certificate);
 
@@ -125,10 +125,8 @@ namespace Certes.Pkcs
                 IsRevocationEnabled = false
             };
 
-            builderParams.AddStore(
-                X509StoreFactory.Create(
-                    "Certificate/Collection",
-                    new X509CollectionStoreParameters(intermediateCerts)));
+            var x509CertStore = CollectionUtilities.CreateStore(intermediateCerts);
+            builderParams.AddStoreCert(x509CertStore);
 
             var builder = new PkixCertPathBuilder();
             var result = builder.Build(builderParams);


### PR DESCRIPTION
Update BouncyCastle library as suggested by @pablopioli should close: #314

## Description

Portable.BouncyCastle is deprecated (last update in 2021) cc: @fszlin 

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary
